### PR TITLE
Update the permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,6 @@
   },
   "permissions": [
     "experimental",
-    "appWindow",
     "storage",
     "unlimitedStorage",
     "alarms",


### PR DESCRIPTION
The appWindow appears to be deprecated and not necessary.(cc https://github.com/GoogleChrome/kendo-photo-booth-app/pull/2)
